### PR TITLE
Improve null time handling

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@ set -ex
 old_version=$1
 new_version=$2
 
-version_files="ruby/lib/forty_time.rb typescript/package.json"
+version_files="ruby/lib/forty_time.rb ruby/Gemfile.lock typescript/package.json"
 commit_message="Bumping version numbers for $new_version"
 tag_message="Tagging version $new_version"
 

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forty_time (0.0.4)
+    forty_time (0.0.6)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby/lib/forty_time.rb
+++ b/ruby/lib/forty_time.rb
@@ -6,7 +6,7 @@ class FortyTime
   class ParseError < StandardError; end
 
   def self.parse(input)
-    return NullFortyTime.new if input.nil?
+    return NullFortyTime.new if input.nil? || input == ''
     return new(input) if input.is_a? Integer
 
     can_parse_string = input.is_a?(String) && input.match?(/:/)

--- a/ruby/lib/forty_time.rb
+++ b/ruby/lib/forty_time.rb
@@ -25,6 +25,8 @@ class FortyTime
 
   attr_accessor :minutes
 
+  alias value minutes
+
   def initialize(minutes)
     @minutes = minutes
   end

--- a/ruby/lib/null_forty_time.rb
+++ b/ruby/lib/null_forty_time.rb
@@ -5,6 +5,8 @@ class NullFortyTime < FortyTime
     super(0)
   end
 
+  def value; end
+
   def +(other)
     other
   end

--- a/ruby/spec/null_forty_time_spec.rb
+++ b/ruby/spec/null_forty_time_spec.rb
@@ -9,6 +9,12 @@ describe NullFortyTime do
     end
   end
 
+  describe 'value' do
+    it 'returns nil' do
+      expect(null_forty_time.value).to eq nil
+    end
+  end
+
   describe 'to_s' do
     it 'returns an empty string' do
       expect(null_forty_time.to_s).to eq ''

--- a/ruby/spec/parse_spec.rb
+++ b/ruby/spec/parse_spec.rb
@@ -3,6 +3,15 @@
 describe FortyTime do
   describe '.parse' do
     context 'with a string' do
+      context 'with an empty string' do
+        it 'returns a NullFortyTime' do
+          input = ''
+
+          forty_time = FortyTime.parse input
+          expect(forty_time).to be_an_instance_of(NullFortyTime)
+        end
+      end
+
       context 'with a random format' do
         it 'raises a parse exception' do
           input = 'asdf'
@@ -41,7 +50,7 @@ describe FortyTime do
     end
 
     context 'with nil' do
-      it 'raises a parse exception' do
+      it 'returns a NullFortyTime' do
         input = nil
 
         forty_time = FortyTime.parse input

--- a/typescript/src/BaseFortyTime.spec.ts
+++ b/typescript/src/BaseFortyTime.spec.ts
@@ -16,6 +16,16 @@ describe("BaseFortyTime", () => {
     })
   })
 
+  describe("value", () => {
+    it("throws an error to implement in subclass", () => {
+      const time = new BaseFortyTime(10)
+
+      expect(() => {
+        time.value
+      }).toThrow(implementError)
+    })
+  })
+
   describe("toString", () => {
     it("throws an error to implement in subclass", () => {
       const time = new BaseFortyTime(10)

--- a/typescript/src/BaseFortyTime.ts
+++ b/typescript/src/BaseFortyTime.ts
@@ -13,6 +13,10 @@ export class BaseFortyTime {
     this.minutes = minutes
   }
 
+  get value(): number | null {
+    throw implementError
+  }
+
   toString = (): string => {
     throw implementError
   }

--- a/typescript/src/FortyTime.spec.ts
+++ b/typescript/src/FortyTime.spec.ts
@@ -39,6 +39,14 @@ describe("FortyTime", () => {
     })
 
     describe("with a string", () => {
+      describe("with an empty string", () => {
+        it("returns a NullFortyTime", () => {
+          const input = ""
+          const fortyTime = FortyTime.parse(input)
+          expect(fortyTime).toBeInstanceOf(NullFortyTime)
+        })
+      })
+
       describe("with a random format", () => {
         it("throws a parse error", () => {
           const input = "asdf"

--- a/typescript/src/FortyTime.spec.ts
+++ b/typescript/src/FortyTime.spec.ts
@@ -110,6 +110,13 @@ describe("FortyTime", () => {
     })
   })
 
+  describe("value", () => {
+    it("returns the minutes", () => {
+      const fortyTime = new FortyTime(480)
+      expect(fortyTime.value).toEqual(480)
+    })
+  })
+
   describe("toString", () => {
     describe("with an input that has no minutes", () => {
       it("returns a properly formatted string", () => {

--- a/typescript/src/FortyTime.ts
+++ b/typescript/src/FortyTime.ts
@@ -2,7 +2,7 @@ import { BaseFortyTime } from "./BaseFortyTime"
 import { NullFortyTime } from "./NullFortyTime"
 
 export class FortyTime extends BaseFortyTime {
-  static parse = (input: number | string | null) => {
+  static parse = (input: number | string | null): BaseFortyTime => {
     if (input === null || input === "") {
       return new NullFortyTime()
     }
@@ -26,6 +26,10 @@ export class FortyTime extends BaseFortyTime {
     let minutes = hours * 60 + extra
 
     return new FortyTime(minutes)
+  }
+
+  get value(): number {
+    return this.minutes
   }
 
   toString = (): string => {

--- a/typescript/src/FortyTime.ts
+++ b/typescript/src/FortyTime.ts
@@ -3,7 +3,7 @@ import { NullFortyTime } from "./NullFortyTime"
 
 export class FortyTime extends BaseFortyTime {
   static parse = (input: number | string | null) => {
-    if (input === null) {
+    if (input === null || input === "") {
       return new NullFortyTime()
     }
 

--- a/typescript/src/NullFortyTime.spec.ts
+++ b/typescript/src/NullFortyTime.spec.ts
@@ -15,6 +15,13 @@ describe("NullFortyTime", () => {
     })
   })
 
+  describe("value", () => {
+    it("returns null", () => {
+      const time = new NullFortyTime()
+      expect(time.value).toEqual(null)
+    })
+  })
+
   describe("toString", () => {
     it("returns an empty string", () => {
       const time = new NullFortyTime()

--- a/typescript/src/NullFortyTime.ts
+++ b/typescript/src/NullFortyTime.ts
@@ -9,6 +9,10 @@ export class NullFortyTime extends BaseFortyTime {
     super(0)
   }
 
+  get value(): null {
+    return null
+  }
+
   toString = (): string => {
     return ""
   }


### PR DESCRIPTION
I realized that I will sometimes want to go back to the value form of a time. Consider the case where a user starts with a null time, then adds an amount of time but then wants to return to a null time. Prior to this PR, this was harder than it had to be. With this change, I can rely on the fact that calling `value` on a FortyTime will return the right thing to persist.

In this same vein, an empty string should be parsed as a null time because that's really the only way an HTML text input can convey the intention to return to a null time.

Finally, I also fixed an oversight where I was not updating the version in the Gemfile.lock.