### PR TITLE
Support 12 hour time

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -11,6 +11,6 @@ tag_message="Tagging version $new_version"
 sed -i "" "s/$old_version/$new_version/g" $version_files
 git add .
 git commit --message "$commit_message"
-git push origin master
+git push origin main
 git tag --annotate v$new_version --message "$tag_message"
 git push origin --tags

--- a/typescript/src/Amount/Amount.spec.ts
+++ b/typescript/src/Amount/Amount.spec.ts
@@ -1,0 +1,156 @@
+import { Amount } from "./Amount"
+import { NullFortyTime } from "../NullFortyTime"
+
+describe("Amount", () => {
+  describe("parsing", () => {
+    describe("with a null", () => {
+      it("returns a NullFortyTime", () => {
+        const input = null
+        const fortyTime = Amount.parse(input)
+        expect(fortyTime).toBeInstanceOf(NullFortyTime)
+        expect(fortyTime.minutes).toEqual(0)
+        expect(fortyTime.toString()).toEqual("")
+      })
+    })
+
+    describe("with an integer", () => {
+      it("parses that number and returns an instance", () => {
+        const input = 480
+        const fortyTime = Amount.parse(input)
+        expect(fortyTime).toBeInstanceOf(Amount)
+      })
+    })
+
+    describe("with a negative integer", () => {
+      it("parses that number and returns an instance", () => {
+        const input = -30
+        const fortyTime = Amount.parse(input)
+        expect(fortyTime).toBeInstanceOf(Amount)
+      })
+    })
+
+    describe("with a float", () => {
+      it("throws a parse error", () => {
+        const input = 480.5
+        expect(() => {
+          Amount.parse(input)
+        }).toThrow(Amount.ParseError)
+      })
+    })
+
+    describe("with a string", () => {
+      describe("with an empty string", () => {
+        it("returns a NullFortyTime", () => {
+          const input = ""
+          const fortyTime = Amount.parse(input)
+          expect(fortyTime).toBeInstanceOf(NullFortyTime)
+        })
+      })
+
+      describe("with a random format", () => {
+        it("throws a parse error", () => {
+          const input = "asdf"
+          expect(() => {
+            Amount.parse(input)
+          }).toThrow(Amount.ParseError)
+        })
+      })
+
+      describe("with proper formatting", () => {
+        it("parses that string and returns an instance", () => {
+          const input = "8:00"
+          const fortyTime = Amount.parse(input)
+          expect(fortyTime).toBeInstanceOf(Amount)
+        })
+      })
+
+      describe("with some negative minutes", () => {
+        it("parses that string and returns an instance with negative minutes", () => {
+          const input = "-0:30"
+          const fortyTime = Amount.parse(input)
+          expect(fortyTime).toBeInstanceOf(Amount)
+          expect(fortyTime.minutes).toEqual(-30)
+        })
+      })
+
+      describe("with some negative hours", () => {
+        it("parses that string and returns an instance with negative minutes", () => {
+          const input = "-1:30"
+          const fortyTime = Amount.parse(input)
+          expect(fortyTime).toBeInstanceOf(Amount)
+          expect(fortyTime.minutes).toEqual(-90)
+        })
+      })
+    })
+  })
+
+  describe("math", () => {
+    it("adds two forty times", () => {
+      const lhs = Amount.parse(480)
+      const rhs = Amount.parse(20)
+      const result = lhs.plus(rhs)
+
+      expect(result.minutes).toEqual(500)
+    })
+
+    it("subtracts two forty times", () => {
+      const lhs = Amount.parse(1020)
+      const rhs = Amount.parse(480)
+      const result = lhs.minus(rhs)
+
+      expect(result.minutes).toEqual(540)
+    })
+
+    it("subtracts negative numbers while adding", () => {
+      const lhs = Amount.parse("8:00")
+      const rhs = Amount.parse("-0:30")
+      const result = lhs.plus(rhs)
+
+      expect(result.minutes).toEqual(450)
+    })
+  })
+
+  describe("value", () => {
+    it("returns the minutes", () => {
+      const fortyTime = new Amount(480)
+      expect(fortyTime.value).toEqual(480)
+    })
+  })
+
+  describe("toString", () => {
+    describe("with an input that has no minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Amount(480)
+        expect(fortyTime.toString()).toEqual("8:00")
+      })
+    })
+
+    describe("with an input that has less than 10 minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Amount(481)
+        expect(fortyTime.toString()).toEqual("8:01")
+      })
+    })
+
+    describe("with an input that has more than 10 minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Amount(491)
+        expect(fortyTime.toString()).toEqual("8:11")
+      })
+    })
+
+    describe("with a negative amount", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Amount(-30)
+        expect(fortyTime.toString()).toEqual("-0:30")
+      })
+    })
+
+    describe("with a large negative amount", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Amount(-601)
+        expect(fortyTime.toString()).toEqual("-10:01")
+      })
+    })
+  })
+})

--- a/typescript/src/Amount/Amount.spec.ts
+++ b/typescript/src/Amount/Amount.spec.ts
@@ -39,6 +39,68 @@ describe("Amount", () => {
     })
 
     describe("with a string", () => {
+      describe("valid amounts", () => {
+        const validAmounts = [
+          ["0", null, ""],
+          ["0:", null, ""],
+          ["0:3", 30, "0:30"],
+          ["0:30", 30, "0:30"],
+          ["1", 60, "1:00"],
+          ["1:", 60, "1:00"],
+          ["1:0", 60, "1:00"],
+          ["1:00", 60, "1:00"],
+          ["11", 660, "11:00"],
+          ["11:", 660, "11:00"],
+          ["11:0", 660, "11:00"],
+          ["11:00", 660, "11:00"],
+          ["-", null, ""],
+          ["-0", null, ""],
+          ["-0:", null, ""],
+          ["-0:3", -30, "-0:30"],
+          ["-0:30", -30, "-0:30"],
+          ["-1", -60, "-1:00"],
+          ["-1:", -60, "-1:00"],
+          ["-1:0", -60, "-1:00"],
+          ["-1:00", -60, "-1:00"],
+          ["-11", -660, "-11:00"],
+          ["-11:", -660, "-11:00"],
+          ["-11:0", -660, "-11:00"],
+          ["-11:00", -660, "-11:00"],
+        ]
+
+        validAmounts.forEach(
+          ([validValue, expectedMinutes, expectedString]) => {
+            it(`returns an Amount with "${expectedMinutes}" minutes and "${expectedString}" as string with "${validValue}"`, () => {
+              const timeAmount = Amount.parse(validValue)
+              expect(timeAmount.value).toEqual(expectedMinutes)
+              expect(timeAmount.toString()).toEqual(expectedString)
+            })
+          }
+        )
+      })
+
+      describe("invalid amounts", () => {
+        const invalidAmounts = [
+          ":",
+          "1-",
+          "-:",
+          ":0",
+          "-:0",
+          ":00",
+          "-11:000",
+          "1:00p",
+          "11:00am",
+        ]
+
+        invalidAmounts.forEach((invalidValue) => {
+          it(`throws a parse error with "${invalidValue}"`, () => {
+            expect(() => {
+              Amount.parse(invalidValue)
+            }).toThrow(Amount.ParseError)
+          })
+        })
+      })
+
       describe("with an empty string", () => {
         it("returns a NullFortyTime", () => {
           const input = ""
@@ -53,32 +115,6 @@ describe("Amount", () => {
           expect(() => {
             Amount.parse(input)
           }).toThrow(Amount.ParseError)
-        })
-      })
-
-      describe("with proper formatting", () => {
-        it("parses that string and returns an instance", () => {
-          const input = "8:00"
-          const fortyTime = Amount.parse(input)
-          expect(fortyTime).toBeInstanceOf(Amount)
-        })
-      })
-
-      describe("with some negative minutes", () => {
-        it("parses that string and returns an instance with negative minutes", () => {
-          const input = "-0:30"
-          const fortyTime = Amount.parse(input)
-          expect(fortyTime).toBeInstanceOf(Amount)
-          expect(fortyTime.minutes).toEqual(-30)
-        })
-      })
-
-      describe("with some negative hours", () => {
-        it("parses that string and returns an instance with negative minutes", () => {
-          const input = "-1:30"
-          const fortyTime = Amount.parse(input)
-          expect(fortyTime).toBeInstanceOf(Amount)
-          expect(fortyTime.minutes).toEqual(-90)
         })
       })
     })

--- a/typescript/src/Amount/Amount.ts
+++ b/typescript/src/Amount/Amount.ts
@@ -1,11 +1,29 @@
 import { BaseFortyTime } from "../BaseFortyTime"
 import { NullFortyTime } from "../NullFortyTime"
 
+const computeMinutes = (timeValue: string): number => {
+  if (timeValue === "-") return 0
+
+  const pattern = /^-?\d{1,2}:?\d{0,2}$/
+  if (!pattern.test(timeValue)) throw new Amount.ParseError()
+
+  const negativeAmount = timeValue[0] === "-"
+  const cleanValue = timeValue.replace("-", "")
+  const [first, last] = cleanValue.split(":")
+
+  const hours = Number(first)
+
+  const multiplier = last?.length === 1 ? 10 : 1
+  const extra = Number(last || "") * multiplier
+
+  const minutes = hours * 60 + extra
+
+  return negativeAmount ? minutes * -1 : minutes
+}
+
 export class Amount extends BaseFortyTime {
   static parse = (input: number | string | null): BaseFortyTime => {
-    if (input === null || input === "") {
-      return new NullFortyTime()
-    }
+    if (input === null || input === "") return new NullFortyTime()
 
     if (typeof input === "number") {
       if (Number.isInteger(input)) {
@@ -15,16 +33,8 @@ export class Amount extends BaseFortyTime {
       }
     }
 
-    if (!input.match(/:/)) throw new Amount.ParseError()
-
-    // eslint-disable-next-line prefer-const
-    let [hours, extra] = input.split(":").map(Number)
-
-    if (input[0] === "-") {
-      extra = extra * -1
-    }
-
-    const minutes = hours * 60 + extra
+    const minutes = computeMinutes(input)
+    if (minutes === 0) return new NullFortyTime()
 
     return new Amount(minutes)
   }
@@ -34,20 +44,15 @@ export class Amount extends BaseFortyTime {
   }
 
   toString = (): string => {
-    let hours: string | number = Math.trunc(this.minutes / 60)
-    let extra: string | number = this.minutes - hours * 60
+    const negativeAmount = this.minutes < 0
+    const absoluteMinutes = Math.abs(this.minutes)
 
-    if (this.minutes < 0) {
-      hours = hours * -1
-      extra = extra * -1
-      hours = `-${hours}`
-    }
+    const sign = negativeAmount ? "-" : ""
+    const hours = Math.trunc(absoluteMinutes / 60)
+    const extra = absoluteMinutes - hours * 60
+    const minutes = extra.toString().padStart(2, "0")
 
-    if (extra < 10) {
-      extra = `0${extra}`
-    }
-
-    return [hours, extra].join(":")
+    return `${sign}${hours}:${minutes}`
   }
 
   plus = (other: BaseFortyTime): BaseFortyTime => {

--- a/typescript/src/Amount/Amount.ts
+++ b/typescript/src/Amount/Amount.ts
@@ -1,0 +1,64 @@
+import { BaseFortyTime } from "../BaseFortyTime"
+import { NullFortyTime } from "../NullFortyTime"
+
+export class Amount extends BaseFortyTime {
+  static parse = (input: number | string | null): BaseFortyTime => {
+    if (input === null || input === "") {
+      return new NullFortyTime()
+    }
+
+    if (typeof input === "number") {
+      if (Number.isInteger(input)) {
+        return new Amount(input)
+      } else {
+        throw new Amount.ParseError()
+      }
+    }
+
+    if (!input.match(/:/)) throw new Amount.ParseError()
+
+    // eslint-disable-next-line prefer-const
+    let [hours, extra] = input.split(":").map(Number)
+
+    if (input[0] === "-") {
+      extra = extra * -1
+    }
+
+    const minutes = hours * 60 + extra
+
+    return new Amount(minutes)
+  }
+
+  get value(): number {
+    return this.minutes
+  }
+
+  toString = (): string => {
+    let hours: string | number = Math.trunc(this.minutes / 60)
+    let extra: string | number = this.minutes - hours * 60
+
+    if (this.minutes < 0) {
+      hours = hours * -1
+      extra = extra * -1
+      hours = `-${hours}`
+    }
+
+    if (extra < 10) {
+      extra = `0${extra}`
+    }
+
+    return [hours, extra].join(":")
+  }
+
+  plus = (other: BaseFortyTime): BaseFortyTime => {
+    const sum = this.minutes + other.minutes
+    const result = new Amount(sum)
+    return result
+  }
+
+  minus = (other: BaseFortyTime): BaseFortyTime => {
+    const diff = this.minutes - other.minutes
+    const result = new Amount(diff)
+    return result
+  }
+}

--- a/typescript/src/Amount/index.ts
+++ b/typescript/src/Amount/index.ts
@@ -1,0 +1,1 @@
+export * from "./Amount"

--- a/typescript/src/Config/Config.ts
+++ b/typescript/src/Config/Config.ts
@@ -1,0 +1,3 @@
+export const Config = {
+  twentyFourHourTime: false,
+}

--- a/typescript/src/Config/index.ts
+++ b/typescript/src/Config/index.ts
@@ -1,0 +1,1 @@
+export * from "./Config"

--- a/typescript/src/FortyTime.spec.ts
+++ b/typescript/src/FortyTime.spec.ts
@@ -16,8 +16,8 @@ describe("FortyTime", () => {
       const ptoAmount = FortyTime.Amount.parse(workWeek.ptoMinutes)
       const adjustAmount = FortyTime.Amount.parse(workWeek.adjustMinutes)
 
-      expect(inPoint.toString()).toEqual("9:00")
-      expect(outPoint.toString()).toEqual("17:00")
+      expect(inPoint.toString()).toEqual("9:00am")
+      expect(outPoint.toString()).toEqual("5:00pm")
 
       expect(ptoAmount.toString()).toEqual("")
       expect(adjustAmount.toString()).toEqual("")
@@ -45,8 +45,8 @@ describe("FortyTime", () => {
       const ptoAmount = FortyTime.Amount.parse(workWeek.ptoMinutes)
       const adjustAmount = FortyTime.Amount.parse(workWeek.adjustMinutes)
 
-      expect(inPoint.toString()).toEqual("10:00")
-      expect(outPoint.toString()).toEqual("17:00")
+      expect(inPoint.toString()).toEqual("10:00am")
+      expect(outPoint.toString()).toEqual("5:00pm")
 
       expect(ptoAmount.toString()).toEqual("1:00")
       expect(adjustAmount.toString()).toEqual("-0:30")

--- a/typescript/src/FortyTime.spec.ts
+++ b/typescript/src/FortyTime.spec.ts
@@ -1,156 +1,61 @@
 import { FortyTime } from "./FortyTime"
-import { NullFortyTime } from "./NullFortyTime"
 
 describe("FortyTime", () => {
-  describe("parsing", () => {
-    describe("with a null", () => {
-      it("returns a NullFortyTime", () => {
-        const input = null
-        const fortyTime = FortyTime.parse(input)
-        expect(fortyTime).toBeInstanceOf(NullFortyTime)
-        expect(fortyTime.minutes).toEqual(0)
-        expect(fortyTime.toString()).toEqual("")
-      })
-    })
+  describe("making a basic work day", () => {
+    it("renders and calculates correctly", () => {
+      const workWeek = {
+        adjustMinutes: null,
+        inMinutes: 540,
+        outMinutes: 1020,
+        ptoMinutes: null,
+      }
 
-    describe("with an integer", () => {
-      it("parses that number and returns an instance", () => {
-        const input = 480
-        const fortyTime = FortyTime.parse(input)
-        expect(fortyTime).toBeInstanceOf(FortyTime)
-      })
-    })
+      const inPoint = new FortyTime.Point(workWeek.inMinutes)
+      const outPoint = new FortyTime.Point(workWeek.outMinutes)
 
-    describe("with a negative integer", () => {
-      it("parses that number and returns an instance", () => {
-        const input = -30
-        const fortyTime = FortyTime.parse(input)
-        expect(fortyTime).toBeInstanceOf(FortyTime)
-      })
-    })
+      const ptoAmount = FortyTime.Amount.parse(workWeek.ptoMinutes)
+      const adjustAmount = FortyTime.Amount.parse(workWeek.adjustMinutes)
 
-    describe("with a float", () => {
-      it("throws a parse error", () => {
-        const input = 480.5
-        expect(() => {
-          FortyTime.parse(input)
-        }).toThrow(FortyTime.ParseError)
-      })
-    })
+      expect(inPoint.toString()).toEqual("9:00")
+      expect(outPoint.toString()).toEqual("17:00")
 
-    describe("with a string", () => {
-      describe("with an empty string", () => {
-        it("returns a NullFortyTime", () => {
-          const input = ""
-          const fortyTime = FortyTime.parse(input)
-          expect(fortyTime).toBeInstanceOf(NullFortyTime)
-        })
-      })
+      expect(ptoAmount.toString()).toEqual("")
+      expect(adjustAmount.toString()).toEqual("")
 
-      describe("with a random format", () => {
-        it("throws a parse error", () => {
-          const input = "asdf"
-          expect(() => {
-            FortyTime.parse(input)
-          }).toThrow(FortyTime.ParseError)
-        })
-      })
-
-      describe("with proper formatting", () => {
-        it("parses that string and returns an instance", () => {
-          const input = "8:00"
-          const fortyTime = FortyTime.parse(input)
-          expect(fortyTime).toBeInstanceOf(FortyTime)
-        })
-      })
-
-      describe("with some negative minutes", () => {
-        it("parses that string and returns an instance with negative minutes", () => {
-          const input = "-0:30"
-          const fortyTime = FortyTime.parse(input)
-          expect(fortyTime).toBeInstanceOf(FortyTime)
-          expect(fortyTime.minutes).toEqual(-30)
-        })
-      })
-
-      describe("with some negative hours", () => {
-        it("parses that string and returns an instance with negative minutes", () => {
-          const input = "-1:30"
-          const fortyTime = FortyTime.parse(input)
-          expect(fortyTime).toBeInstanceOf(FortyTime)
-          expect(fortyTime.minutes).toEqual(-90)
-        })
-      })
+      const totalAmount = outPoint
+        .minus(inPoint)
+        .plus(ptoAmount)
+        .plus(adjustAmount)
+      expect(totalAmount.value).toEqual(480)
     })
   })
 
-  describe("math", () => {
-    it("adds two forty times", () => {
-      const lhs = FortyTime.parse(480)
-      const rhs = FortyTime.parse(20)
-      const result = lhs.plus(rhs)
+  describe("making a complex day", () => {
+    it("renders and calculates correctly", () => {
+      const workWeek = {
+        adjustMinutes: -30,
+        inMinutes: 600,
+        outMinutes: 1020,
+        ptoMinutes: 60,
+      }
 
-      expect(result.minutes).toEqual(500)
-    })
+      const inPoint = new FortyTime.Point(workWeek.inMinutes)
+      const outPoint = new FortyTime.Point(workWeek.outMinutes)
 
-    it("subtracts two forty times", () => {
-      const lhs = FortyTime.parse(1020)
-      const rhs = FortyTime.parse(480)
-      const result = lhs.minus(rhs)
+      const ptoAmount = FortyTime.Amount.parse(workWeek.ptoMinutes)
+      const adjustAmount = FortyTime.Amount.parse(workWeek.adjustMinutes)
 
-      expect(result.minutes).toEqual(540)
-    })
+      expect(inPoint.toString()).toEqual("10:00")
+      expect(outPoint.toString()).toEqual("17:00")
 
-    it("subtracts negative numbers while adding", () => {
-      const lhs = FortyTime.parse("8:00")
-      const rhs = FortyTime.parse("-0:30")
-      const result = lhs.plus(rhs)
+      expect(ptoAmount.toString()).toEqual("1:00")
+      expect(adjustAmount.toString()).toEqual("-0:30")
 
-      expect(result.minutes).toEqual(450)
-    })
-  })
-
-  describe("value", () => {
-    it("returns the minutes", () => {
-      const fortyTime = new FortyTime(480)
-      expect(fortyTime.value).toEqual(480)
-    })
-  })
-
-  describe("toString", () => {
-    describe("with an input that has no minutes", () => {
-      it("returns a properly formatted string", () => {
-        const fortyTime = new FortyTime(480)
-        expect(fortyTime.toString()).toEqual("8:00")
-      })
-    })
-
-    describe("with an input that has less than 10 minutes", () => {
-      it("returns a properly formatted string", () => {
-        const fortyTime = new FortyTime(481)
-        expect(fortyTime.toString()).toEqual("8:01")
-      })
-    })
-
-    describe("with an input that has more than 10 minutes", () => {
-      it("returns a properly formatted string", () => {
-        const fortyTime = new FortyTime(491)
-        expect(fortyTime.toString()).toEqual("8:11")
-      })
-    })
-
-    describe("with a negative amount", () => {
-      it("returns a properly formatted string", () => {
-        const fortyTime = new FortyTime(-30)
-        expect(fortyTime.toString()).toEqual("-0:30")
-      })
-    })
-
-    describe("with a large negative amount", () => {
-      it("returns a properly formatted string", () => {
-        const fortyTime = new FortyTime(-601)
-        expect(fortyTime.toString()).toEqual("-10:01")
-      })
+      const totalAmount = outPoint
+        .minus(inPoint)
+        .plus(ptoAmount)
+        .plus(adjustAmount)
+      expect(totalAmount.value).toEqual(450)
     })
   })
 })

--- a/typescript/src/FortyTime.ts
+++ b/typescript/src/FortyTime.ts
@@ -1,7 +1,9 @@
 import { Amount } from "./Amount"
+import { Config } from "./Config"
 import { Point } from "./Point"
 
 export const FortyTime = {
   Amount,
+  Config,
   Point,
 }

--- a/typescript/src/FortyTime.ts
+++ b/typescript/src/FortyTime.ts
@@ -1,64 +1,7 @@
-import { BaseFortyTime } from "./BaseFortyTime"
-import { NullFortyTime } from "./NullFortyTime"
+import { Amount } from "./Amount"
+import { Point } from "./Point"
 
-export class FortyTime extends BaseFortyTime {
-  static parse = (input: number | string | null): BaseFortyTime => {
-    if (input === null || input === "") {
-      return new NullFortyTime()
-    }
-
-    if (typeof input === "number") {
-      if (Number.isInteger(input)) {
-        return new FortyTime(input)
-      } else {
-        throw new FortyTime.ParseError()
-      }
-    }
-
-    if (!input.match(/:/)) throw new FortyTime.ParseError()
-
-    // eslint-disable-next-line prefer-const
-    let [hours, extra] = input.split(":").map(Number)
-
-    if (input[0] === "-") {
-      extra = extra * -1
-    }
-
-    const minutes = hours * 60 + extra
-
-    return new FortyTime(minutes)
-  }
-
-  get value(): number {
-    return this.minutes
-  }
-
-  toString = (): string => {
-    let hours: string | number = Math.trunc(this.minutes / 60)
-    let extra: string | number = this.minutes - hours * 60
-
-    if (this.minutes < 0) {
-      hours = hours * -1
-      extra = extra * -1
-      hours = `-${hours}`
-    }
-
-    if (extra < 10) {
-      extra = `0${extra}`
-    }
-
-    return [hours, extra].join(":")
-  }
-
-  plus = (other: BaseFortyTime): BaseFortyTime => {
-    const sum = this.minutes + other.minutes
-    const result = new FortyTime(sum)
-    return result
-  }
-
-  minus = (other: BaseFortyTime): BaseFortyTime => {
-    const diff = this.minutes - other.minutes
-    const result = new FortyTime(diff)
-    return result
-  }
+export const FortyTime = {
+  Amount,
+  Point,
 }

--- a/typescript/src/Point/Point.spec.ts
+++ b/typescript/src/Point/Point.spec.ts
@@ -1,0 +1,154 @@
+import { Point } from "./Point"
+import { NullFortyTime } from "../NullFortyTime"
+
+describe("Point", () => {
+  describe("construction", () => {
+    describe("with a positive number", () => {
+      it("returns a Point", () => {
+        const minutes = 480
+        const fortyTime = new Point(minutes)
+        expect(fortyTime).toBeInstanceOf(Point)
+      })
+    })
+
+    describe("with a negative number", () => {
+      it("throws a parse error", () => {
+        const minutes = -480
+        expect(() => {
+          new Point(minutes)
+        }).toThrow(Point.ParseError)
+      })
+    })
+  })
+
+  describe("parsing", () => {
+    describe("with a null", () => {
+      it("returns a NullFortyTime", () => {
+        const input = null
+        const fortyTime = Point.parse(input)
+        expect(fortyTime).toBeInstanceOf(NullFortyTime)
+        expect(fortyTime.minutes).toEqual(0)
+        expect(fortyTime.toString()).toEqual("")
+      })
+    })
+
+    describe("with an integer", () => {
+      it("parses that number and returns an instance", () => {
+        const input = 480
+        const fortyTime = Point.parse(input)
+        expect(fortyTime).toBeInstanceOf(Point)
+      })
+    })
+
+    describe("with a negative integer", () => {
+      it("throws a parse error", () => {
+        const input = -30
+        expect(() => {
+          Point.parse(input)
+        }).toThrow(Point.ParseError)
+      })
+    })
+
+    describe("with a float", () => {
+      it("throws a parse error", () => {
+        const input = 480.5
+        expect(() => {
+          Point.parse(input)
+        }).toThrow(Point.ParseError)
+      })
+    })
+
+    describe("with a string", () => {
+      describe("with an empty string", () => {
+        it("returns a NullFortyTime", () => {
+          const input = ""
+          const fortyTime = Point.parse(input)
+          expect(fortyTime).toBeInstanceOf(NullFortyTime)
+        })
+      })
+
+      describe("with a random format", () => {
+        it("throws a parse error", () => {
+          const input = "asdf"
+          expect(() => {
+            Point.parse(input)
+          }).toThrow(Point.ParseError)
+        })
+      })
+
+      describe("with proper formatting", () => {
+        it("parses that string and returns an instance", () => {
+          const input = "8:00"
+          const fortyTime = Point.parse(input)
+          expect(fortyTime).toBeInstanceOf(Point)
+        })
+      })
+
+      describe("with some negative minutes", () => {
+        it("throws a parse error", () => {
+          const input = "-0:30"
+          expect(() => {
+            Point.parse(input)
+          }).toThrow(Point.ParseError)
+        })
+      })
+
+      describe("with some negative hours", () => {
+        it("throws a parse error", () => {
+          const input = "-1:30"
+          expect(() => {
+            Point.parse(input)
+          }).toThrow(Point.ParseError)
+        })
+      })
+    })
+  })
+
+  describe("math", () => {
+    it("adds two forty times", () => {
+      const lhs = Point.parse(480)
+      const rhs = Point.parse(20)
+      const result = lhs.plus(rhs)
+
+      expect(result.minutes).toEqual(500)
+    })
+
+    it("subtracts two forty times", () => {
+      const lhs = Point.parse(1020)
+      const rhs = Point.parse(480)
+      const result = lhs.minus(rhs)
+
+      expect(result.minutes).toEqual(540)
+    })
+  })
+
+  describe("value", () => {
+    it("returns the minutes", () => {
+      const fortyTime = new Point(480)
+      expect(fortyTime.value).toEqual(480)
+    })
+  })
+
+  describe("toString", () => {
+    describe("with an input that has no minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Point(480)
+        expect(fortyTime.toString()).toEqual("8:00")
+      })
+    })
+
+    describe("with an input that has less than 10 minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Point(481)
+        expect(fortyTime.toString()).toEqual("8:01")
+      })
+    })
+
+    describe("with an input that has more than 10 minutes", () => {
+      it("returns a properly formatted string", () => {
+        const fortyTime = new Point(491)
+        expect(fortyTime.toString()).toEqual("8:11")
+      })
+    })
+  })
+})

--- a/typescript/src/Point/Point.spec.ts
+++ b/typescript/src/Point/Point.spec.ts
@@ -59,6 +59,57 @@ describe("Point", () => {
     })
 
     describe("with a string", () => {
+      describe("valid points", () => {
+        const validPoints = [
+          ["1", 60, "1:00am"],
+          ["1:", 60, "1:00am"],
+          ["1:0", 60, "1:00am"],
+          ["1:00", 60, "1:00am"],
+          ["1:00a", 60, "1:00am"],
+          ["1:00am", 60, "1:00am"],
+          ["1:00p", 780, "1:00pm"],
+          ["1:00pm", 780, "1:00pm"],
+          ["11", 660, "11:00am"],
+          ["11:", 660, "11:00am"],
+          ["11:0", 660, "11:00am"],
+          ["11:00", 660, "11:00am"],
+          ["11:00a", 660, "11:00am"],
+          ["11:00am", 660, "11:00am"],
+          ["11:00p", 1380, "11:00pm"],
+          ["11:00pm", 1380, "11:00pm"],
+        ]
+
+        validPoints.forEach(([validValue, expectedMinutes, expectedString]) => {
+          it(`returns a Point with "${expectedMinutes}" minutes and "${expectedString}" as string with "${validValue}"`, () => {
+            const timePoint = Point.parse(validValue)
+            expect(timePoint.value).toEqual(expectedMinutes)
+            expect(timePoint.toString()).toEqual(expectedString)
+          })
+        })
+      })
+
+      describe("invalid points", () => {
+        const invalidPoints = [
+          ":",
+          "1-",
+          "-:",
+          ":0",
+          "-:0",
+          ":00",
+          "-1:00",
+          "-1:00m",
+          "-11:000",
+        ]
+
+        invalidPoints.forEach((invalidValue) => {
+          it(`throws a parse error with ${invalidValue}`, () => {
+            expect(() => {
+              Point.parse(invalidValue)
+            }).toThrow(Point.ParseError)
+          })
+        })
+      })
+
       describe("with an empty string", () => {
         it("returns a NullFortyTime", () => {
           const input = ""
@@ -70,32 +121,6 @@ describe("Point", () => {
       describe("with a random format", () => {
         it("throws a parse error", () => {
           const input = "asdf"
-          expect(() => {
-            Point.parse(input)
-          }).toThrow(Point.ParseError)
-        })
-      })
-
-      describe("with proper formatting", () => {
-        it("parses that string and returns an instance", () => {
-          const input = "8:00"
-          const fortyTime = Point.parse(input)
-          expect(fortyTime).toBeInstanceOf(Point)
-        })
-      })
-
-      describe("with some negative minutes", () => {
-        it("throws a parse error", () => {
-          const input = "-0:30"
-          expect(() => {
-            Point.parse(input)
-          }).toThrow(Point.ParseError)
-        })
-      })
-
-      describe("with some negative hours", () => {
-        it("throws a parse error", () => {
-          const input = "-1:30"
           expect(() => {
             Point.parse(input)
           }).toThrow(Point.ParseError)
@@ -133,21 +158,21 @@ describe("Point", () => {
     describe("with an input that has no minutes", () => {
       it("returns a properly formatted string", () => {
         const fortyTime = new Point(480)
-        expect(fortyTime.toString()).toEqual("8:00")
+        expect(fortyTime.toString()).toEqual("8:00am")
       })
     })
 
     describe("with an input that has less than 10 minutes", () => {
       it("returns a properly formatted string", () => {
         const fortyTime = new Point(481)
-        expect(fortyTime.toString()).toEqual("8:01")
+        expect(fortyTime.toString()).toEqual("8:01am")
       })
     })
 
     describe("with an input that has more than 10 minutes", () => {
       it("returns a properly formatted string", () => {
         const fortyTime = new Point(491)
-        expect(fortyTime.toString()).toEqual("8:11")
+        expect(fortyTime.toString()).toEqual("8:11am")
       })
     })
   })

--- a/typescript/src/Point/Point.spec.ts
+++ b/typescript/src/Point/Point.spec.ts
@@ -1,3 +1,5 @@
+import { FortyTime } from "../FortyTime"
+import { Config } from "../Config"
 import { Point } from "./Point"
 import { NullFortyTime } from "../NullFortyTime"
 
@@ -62,6 +64,10 @@ describe("Point", () => {
       describe("valid points", () => {
         const validPoints = [
           ["1", 60, "1:00am"],
+          ["1a", 60, "1:00am"],
+          ["1am", 60, "1:00am"],
+          ["1p", 780, "1:00pm"],
+          ["1pm", 780, "1:00pm"],
           ["1:", 60, "1:00am"],
           ["1:0", 60, "1:00am"],
           ["1:00", 60, "1:00am"],
@@ -70,6 +76,10 @@ describe("Point", () => {
           ["1:00p", 780, "1:00pm"],
           ["1:00pm", 780, "1:00pm"],
           ["11", 660, "11:00am"],
+          ["11a", 660, "11:00am"],
+          ["11am", 660, "11:00am"],
+          ["11p", 1380, "11:00pm"],
+          ["11pm", 1380, "11:00pm"],
           ["11:", 660, "11:00am"],
           ["11:0", 660, "11:00am"],
           ["11:00", 660, "11:00am"],
@@ -99,6 +109,10 @@ describe("Point", () => {
           "-1:00",
           "-1:00m",
           "-11:000",
+          "17",
+          "17:",
+          "17:0",
+          "17:00",
         ]
 
         invalidPoints.forEach((invalidValue) => {
@@ -124,6 +138,81 @@ describe("Point", () => {
           expect(() => {
             Point.parse(input)
           }).toThrow(Point.ParseError)
+        })
+      })
+
+      describe("with twentyFourHourTime turned on", () => {
+        beforeAll(() => {
+          FortyTime.Config = { twentyFourHourTime: true }
+        })
+
+        afterAll(() => {
+          FortyTime.Config = Config
+        })
+
+        describe("valid points", () => {
+          const validPoints = [
+            ["1", 60, "1:00"],
+            ["1:", 60, "1:00"],
+            ["1:0", 60, "1:00"],
+            ["1:00", 60, "1:00"],
+            ["11", 660, "11:00"],
+            ["11:", 660, "11:00"],
+            ["11:0", 660, "11:00"],
+            ["11:00", 660, "11:00"],
+            ["17", 1020, "17:00"],
+            ["17:", 1020, "17:00"],
+            ["17:0", 1020, "17:00"],
+            ["17:00", 1020, "17:00"],
+          ]
+
+          validPoints.forEach(
+            ([validValue, expectedMinutes, expectedString]) => {
+              it(`returns a Point with "${expectedMinutes}" minutes and "${expectedString}" as string with "${validValue}"`, () => {
+                const timePoint = Point.parse(validValue)
+                expect(timePoint.value).toEqual(expectedMinutes)
+                expect(timePoint.toString()).toEqual(expectedString)
+              })
+            }
+          )
+        })
+
+        describe("invalid points", () => {
+          const invalidPoints = [
+            ":",
+            "1-",
+            "-:",
+            ":0",
+            "-:0",
+            ":00",
+            "-1:00",
+            "-1:00m",
+            "-11:000",
+            "1a",
+            "1am",
+            "1p",
+            "1pm",
+            "1:00a",
+            "1:00am",
+            "1:00p",
+            "1:00pm",
+            "11a",
+            "11am",
+            "11p",
+            "11pm",
+            "11:00a",
+            "11:00am",
+            "11:00p",
+            "11:00pm",
+          ]
+
+          invalidPoints.forEach((invalidValue) => {
+            it(`throws a parse error with ${invalidValue}`, () => {
+              expect(() => {
+                Point.parse(invalidValue)
+              }).toThrow(Point.ParseError)
+            })
+          })
         })
       })
     })

--- a/typescript/src/Point/Point.ts
+++ b/typescript/src/Point/Point.ts
@@ -1,0 +1,63 @@
+import { BaseFortyTime } from "../BaseFortyTime"
+import { NullFortyTime } from "../NullFortyTime"
+
+export class Point extends BaseFortyTime {
+  static parse = (input: number | string | null): BaseFortyTime => {
+    if (input === null || input === "") {
+      return new NullFortyTime()
+    }
+
+    if (typeof input === "number") {
+      if (Number.isInteger(input) && input > 0) {
+        return new Point(input)
+      } else {
+        throw new Point.ParseError()
+      }
+    }
+
+    if (!input.match(/:/)) throw new Point.ParseError()
+
+    // eslint-disable-next-line prefer-const
+    let [hours, extra] = input.split(":").map(Number)
+
+    if (input[0] === "-") {
+      throw new Point.ParseError()
+    }
+
+    const minutes = hours * 60 + extra
+
+    return new Point(minutes)
+  }
+
+  get value(): number {
+    return this.minutes
+  }
+
+  constructor(minutes: number) {
+    super(minutes)
+    if (minutes < 0) throw new Point.ParseError()
+  }
+
+  toString = (): string => {
+    const hours: number = Math.trunc(this.minutes / 60)
+    let extra: string | number = this.minutes - hours * 60
+
+    if (extra < 10) {
+      extra = `0${extra}`
+    }
+
+    return [hours, extra].join(":")
+  }
+
+  plus = (other: BaseFortyTime): BaseFortyTime => {
+    const sum = this.minutes + other.minutes
+    const result = new Point(sum)
+    return result
+  }
+
+  minus = (other: BaseFortyTime): BaseFortyTime => {
+    const diff = this.minutes - other.minutes
+    const result = new Point(diff)
+    return result
+  }
+}

--- a/typescript/src/Point/Point.ts
+++ b/typescript/src/Point/Point.ts
@@ -1,14 +1,22 @@
 import { BaseFortyTime } from "../BaseFortyTime"
+import { FortyTime } from "../FortyTime"
 import { NullFortyTime } from "../NullFortyTime"
 
 const computeMinutes = (timeValue: string): number => {
-  const pattern = /^\d{1,2}:?\d{0,2}(a|p)?m?$/
+  const { twentyFourHourTime } = FortyTime.Config
+
+  const twentyFourHourPattern = /^\d{1,2}:?\d{0,2}$/
+  const twelveHourPattern = /^\d{1,2}:?\d{0,2}(a|p)?m?$/
+
+  const pattern = twentyFourHourTime ? twentyFourHourPattern : twelveHourPattern
 
   if (!pattern.test(timeValue)) throw new Point.ParseError()
 
   const add12Hours = /pm?/.test(timeValue)
   const cleanValue = timeValue.replace(/(a|p)m?/, "")
   const [first, last] = cleanValue.split(":")
+
+  if (!twentyFourHourTime && Number(first) > 12) throw new Point.ParseError()
 
   const offset = add12Hours ? 12 : 0
   const hours = Number(first) + offset
@@ -47,17 +55,23 @@ export class Point extends BaseFortyTime {
   }
 
   toString = (): string => {
+    const { twentyFourHourTime } = FortyTime.Config
+
     let hours = Math.trunc(this.minutes / 60)
     const extra = this.minutes - hours * 60
     const minutes = extra.toString().padStart(2, "0")
 
     const meridianIndicator = hours < 12 ? "am" : "pm"
 
-    if (hours > 12) {
+    if (!twentyFourHourTime && hours > 12) {
       hours -= 12
     }
 
-    return `${hours}:${minutes}${meridianIndicator}`
+    if (twentyFourHourTime) {
+      return `${hours}:${minutes}`
+    } else {
+      return `${hours}:${minutes}${meridianIndicator}`
+    }
   }
 
   plus = (other: BaseFortyTime): BaseFortyTime => {

--- a/typescript/src/Point/Point.ts
+++ b/typescript/src/Point/Point.ts
@@ -1,11 +1,27 @@
 import { BaseFortyTime } from "../BaseFortyTime"
 import { NullFortyTime } from "../NullFortyTime"
 
+const computeMinutes = (timeValue: string): number => {
+  const pattern = /^\d{1,2}:?\d{0,2}(a|p)?m?$/
+
+  if (!pattern.test(timeValue)) throw new Point.ParseError()
+
+  const add12Hours = /pm?/.test(timeValue)
+  const cleanValue = timeValue.replace(/(a|p)m?/, "")
+  const [first, last] = cleanValue.split(":")
+
+  const offset = add12Hours ? 12 : 0
+  const hours = Number(first) + offset
+
+  const multiplier = last?.length === 1 ? 10 : 1
+  const extra = Number(last || "") * multiplier
+
+  return hours * 60 + extra
+}
+
 export class Point extends BaseFortyTime {
   static parse = (input: number | string | null): BaseFortyTime => {
-    if (input === null || input === "") {
-      return new NullFortyTime()
-    }
+    if (input === null || input === "") return new NullFortyTime()
 
     if (typeof input === "number") {
       if (Number.isInteger(input) && input > 0) {
@@ -15,16 +31,8 @@ export class Point extends BaseFortyTime {
       }
     }
 
-    if (!input.match(/:/)) throw new Point.ParseError()
-
-    // eslint-disable-next-line prefer-const
-    let [hours, extra] = input.split(":").map(Number)
-
-    if (input[0] === "-") {
-      throw new Point.ParseError()
-    }
-
-    const minutes = hours * 60 + extra
+    const minutes = computeMinutes(input)
+    if (minutes === 0) return new NullFortyTime()
 
     return new Point(minutes)
   }
@@ -39,14 +47,17 @@ export class Point extends BaseFortyTime {
   }
 
   toString = (): string => {
-    const hours: number = Math.trunc(this.minutes / 60)
-    let extra: string | number = this.minutes - hours * 60
+    let hours = Math.trunc(this.minutes / 60)
+    const extra = this.minutes - hours * 60
+    const minutes = extra.toString().padStart(2, "0")
 
-    if (extra < 10) {
-      extra = `0${extra}`
+    const meridianIndicator = hours < 12 ? "am" : "pm"
+
+    if (hours > 12) {
+      hours -= 12
     }
 
-    return [hours, extra].join(":")
+    return `${hours}:${minutes}${meridianIndicator}`
   }
 
   plus = (other: BaseFortyTime): BaseFortyTime => {

--- a/typescript/src/Point/index.ts
+++ b/typescript/src/Point/index.ts
@@ -1,0 +1,1 @@
+export * from "./Point"


### PR DESCRIPTION
This is a pretty major refactoring - the goal is to support both 12 and 24 hour times. Like, I want people to be able to enter `1:00pm` and have that accepted. But it should be able to be globally configured so I got that in too.

```ts
// before
const inTime = FortyTime.parse(inMinutes)
const ptoTime = FortyTime.parse(ptoMinutes)

// after
const inPoint = FortyTime.Point.parse(inMinutes)
const ptoAmount = FortyTime.Amount.parse(ptoMinutes)
```

So the biggest difference is that `FortyTime` is now a namespace and I've introduced the concepts of `Amount` and `Point`. These two behave slightly differently:

* only an amount of time can be negative
* when in 12 hour mode a point in time can be specified with meridian indicator
* when in 12 hour mode a point in time displays its meridian indicator

I have made the 12 hour mode default btw. Configuration is done like so:

```ts
// turn on the 24-hour time configuration:
FortyTime.Config = { twentyFourHourTime: true }
```

The other big difference here is that I'm accepting WAY more partial values and coercing them when possible. This is best reviewed by looking at the tests where I have arrays of valid and invalid values. This simulates the user input and helps demonstrate that we can now accept lots of different kinds of user input. The way I think I'll use this most is:

* entering simply `9` in the `in` field
* entering `5p` in the `out` field

With 12 hour mode as default that will result in `9:00am` and `5:00pm` being updated in the fields and the right amount of minutes being store in the database. Much more humane! 